### PR TITLE
Fix recipe fetch flag in RecipeSwipeScreen

### DIFF
--- a/app/src/main/java/com/smartkitchen/ui/RecipeSwipeScreen.kt
+++ b/app/src/main/java/com/smartkitchen/ui/RecipeSwipeScreen.kt
@@ -37,7 +37,7 @@ fun RecipeSwipeScreen(
 
     // Get the saved state handle to check if we should fetch recipes
     val savedStateHandle = navController.currentBackStackEntry?.savedStateHandle
-    val shouldFetchRecipes = true //savedStateHandle?.get<Boolean>("shouldFetchRecipes") ?: false
+    val shouldFetchRecipes = savedStateHandle?.get<Boolean>("shouldFetchRecipes") ?: false
 
     // Effect to fetch recipes when navigating to this screen with the flag set
     LaunchedEffect(shouldFetchRecipes) {


### PR DESCRIPTION
## Summary
- properly read navigation saved state to decide when to fetch recipes

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_685d35de8dd88322a9eb3c75dba85020